### PR TITLE
Remove reading group link from nav

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,7 +166,6 @@ function App() {
             <Nav>
               <Logo to="/">LIBRO</Logo><NavLinks>
               <NavLink to="/reading-record">독서 기록</NavLink>
-              <NavLink to="/reading-group">독서 모임</NavLink>
               {!isAuthenticated ? (
                 <NavLink to="/login">로그인</NavLink>
             ) : (


### PR DESCRIPTION
## Summary
- remove NavLink for the `/reading-group` route

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68455c92b0d48320b9ae10567cb93e2a